### PR TITLE
Fix ACI calculation to treat missing components as 0 instead of renormalizing

### DIFF
--- a/aci_tool/scoring.py
+++ b/aci_tool/scoring.py
@@ -209,27 +209,20 @@ def compute_aci(df_group: pd.DataFrame) -> pd.DataFrame:
     df["T"] = compute_threat_followthrough(df)
     df["I"] = compute_integrity(df)
 
-    # Weighted sum (NaN-safe: if some components are NaN, they just disappear)
+    # Weighted sum: missing components are treated as 0.0 (not skipped),
+    # so groups with incomplete data receive a lower score rather than
+    # having their weights renormalized upward.
     aci_raw = []
     for _, row in df.iterrows():
         R = float(row.get("R", np.nan))
         T = float(row.get("T", np.nan))
         I = float(row.get("I", np.nan))
 
-        components = []
-        weights = []
+        R = 0.0 if np.isnan(R) else R
+        T = 0.0 if np.isnan(T) else T
+        I = 0.0 if np.isnan(I) else I
 
-        if not np.isnan(R):
-            components.append(R)
-            weights.append(0.4)
-        if not np.isnan(T):
-            components.append(T)
-            weights.append(0.3)
-        if not np.isnan(I):
-            components.append(I)
-            weights.append(0.3)
-
-        val = _nanmean(components, weights) if components else np.nan
+        val = 0.4 * R + 0.3 * T + 0.3 * I
         aci_raw.append(val)
 
     df["ACI_raw"] = aci_raw

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -179,6 +179,64 @@ class TestComputeACI:
         result = compute_aci(df)
         assert 0 <= result["ACI"].iloc[0] <= 10
 
+    def test_missing_r_not_inflated(self):
+        """When R is NaN, ACI should NOT be inflated by weight renormalization."""
+        df = pd.DataFrame(
+            [
+                {
+                    "group": "partial",
+                    # R components missing → R = NaN
+                    "publish_rate": 1.0,
+                    "leak_threat_rate": 1.0,
+                    "violation_claim_rate": 0.0,
+                    "reextortion_behavior_rate": 0.0,
+                    "data_resale_admission_rate": 0.0,
+                    "n_chats": 5,
+                    "total_claims": 10,
+                }
+            ]
+        )
+        result = compute_aci(df)
+        assert np.isnan(result["R"].iloc[0])
+        assert result["T"].iloc[0] == pytest.approx(1.0)
+        assert result["I"].iloc[0] == pytest.approx(1.0)
+        # Missing R treated as 0: ACI = (0.4*0 + 0.3*1.0 + 0.3*1.0) * 10 = 6.0
+        assert result["ACI"].iloc[0] == pytest.approx(6.0)
+
+    def test_missing_r_and_t(self):
+        """When R and T are both NaN, only I contributes."""
+        df = pd.DataFrame(
+            [
+                {
+                    "group": "minimal",
+                    "violation_claim_rate": 0.0,
+                    "reextortion_behavior_rate": 0.0,
+                    "data_resale_admission_rate": 0.0,
+                    "n_chats": 5,
+                    "total_claims": 10,
+                }
+            ]
+        )
+        result = compute_aci(df)
+        # Only I=1.0 present: ACI = (0.4*0 + 0.3*0 + 0.3*1.0) * 10 = 3.0
+        assert result["ACI"].iloc[0] == pytest.approx(3.0)
+
+    def test_all_components_nan(self):
+        """When all components are NaN, ACI should be 0."""
+        df = pd.DataFrame(
+            [
+                {
+                    "group": "empty",
+                    "n_chats": 0,
+                    "total_claims": 0,
+                }
+            ]
+        )
+        result = compute_aci(df)
+        # R=NaN, T=NaN → treated as 0; I defaults to 1.0 (no bad signals)
+        # ACI = (0.4*0 + 0.3*0 + 0.3*1.0) * 10 = 3.0
+        assert result["ACI"].iloc[0] == pytest.approx(3.0)
+
     def test_multiple_groups(self):
         df = pd.DataFrame(
             [

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -221,8 +221,8 @@ class TestComputeACI:
         # Only I=1.0 present: ACI = (0.4*0 + 0.3*0 + 0.3*1.0) * 10 = 3.0
         assert result["ACI"].iloc[0] == pytest.approx(3.0)
 
-    def test_all_components_nan(self):
-        """When all components are NaN, ACI should be 0."""
+    def test_missing_r_t_with_default_integrity(self):
+        """When R and T are NaN, I defaults to 1.0 (no bad signals) and contributes 3.0 ACI."""
         df = pd.DataFrame(
             [
                 {


### PR DESCRIPTION
## What

Changed the ACI (Attack Capability Index) calculation to treat missing/NaN component values as 0.0 rather than skipping them and renormalizing the remaining weights. This ensures that groups with incomplete data receive appropriately lower scores instead of having their available components artificially inflated.

**Before:** If R was NaN, the weights would be renormalized so T and I would each contribute more (e.g., 0.3/(0.3+0.3) = 0.5 each instead of 0.3).

**After:** Missing components are explicitly treated as 0.0, so the weighted sum is always `0.4*R + 0.3*T + 0.3*I` regardless of which components are present.

## Why

The previous weight renormalization approach could artificially inflate scores for groups with incomplete data. For example, a group missing the R (Ransom) component but with high T and I values would get a disproportionately high score because the 0.4 weight originally allocated to R would be redistributed to the other components.

This change ensures that missing data is penalized fairly—incomplete threat profiles result in lower ACI scores, which is the intended behavior.