### PR TITLE
Handle invalid IPv6 URLs in sentence encoding

### DIFF
--- a/aci_tool/chat_semantic.py
+++ b/aci_tool/chat_semantic.py
@@ -95,11 +95,13 @@ def classify_sentence_semantic(
     model, proto_embs = _get_model_and_prototypes()
     try:
         emb = model.encode(sentence, normalize_embeddings=True)
-    except ValueError:
+    except ValueError as exc:
         # sentence_transformers' modality detection runs urlparse() on inputs to
         # check for image URLs. Chat content with truncated bracketed URLs like
         # 'https://[onion...' makes Python 3.11+ raise "Invalid IPv6 URL".
-        # Strip square brackets and retry.
+        # Only swallow that specific case; other ValueErrors are real bugs.
+        if "Invalid IPv6 URL" not in str(exc):
+            raise
         emb = model.encode(re.sub(r"[\[\]]", " ", sentence), normalize_embeddings=True)
 
     hits: Dict[str, bool] = {}

--- a/aci_tool/chat_semantic.py
+++ b/aci_tool/chat_semantic.py
@@ -93,7 +93,14 @@ def classify_sentence_semantic(
         return {label: False for label in PROTOTYPES.keys()}
 
     model, proto_embs = _get_model_and_prototypes()
-    emb = model.encode(sentence, normalize_embeddings=True)
+    try:
+        emb = model.encode(sentence, normalize_embeddings=True)
+    except ValueError:
+        # sentence_transformers' modality detection runs urlparse() on inputs to
+        # check for image URLs. Chat content with truncated bracketed URLs like
+        # 'https://[onion...' makes Python 3.11+ raise "Invalid IPv6 URL".
+        # Strip square brackets and retry.
+        emb = model.encode(re.sub(r"[\[\]]", " ", sentence), normalize_embeddings=True)
 
     hits: Dict[str, bool] = {}
     for label, label_embs in proto_embs.items():

--- a/tests/test_chat_semantic.py
+++ b/tests/test_chat_semantic.py
@@ -93,9 +93,7 @@ class TestClassifyIPv6Fallback:
                     raise ValueError("Invalid IPv6 URL")
                 return [0.0]
 
-        monkeypatch.setattr(
-            chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {})
-        )
+        monkeypatch.setattr(chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {}))
 
         result = chat_semantic.classify_sentence_semantic("visit https://[onion-link")
         assert result == {}
@@ -109,9 +107,7 @@ class TestClassifyIPv6Fallback:
             def encode(self, text, normalize_embeddings=True):
                 raise ValueError("some other problem")
 
-        monkeypatch.setattr(
-            chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {})
-        )
+        monkeypatch.setattr(chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {}))
 
         with pytest.raises(ValueError, match="some other problem"):
             chat_semantic.classify_sentence_semantic("hello world")

--- a/tests/test_chat_semantic.py
+++ b/tests/test_chat_semantic.py
@@ -76,6 +76,47 @@ class TestIsAttackerMessage:
         assert is_attacker_message({}) is True  # default: not victim
 
 
+class TestClassifyIPv6Fallback:
+    """sentence_transformers' modality detection raises 'Invalid IPv6 URL' on
+    truncated bracketed URLs in chat content. We catch only that case and retry
+    with brackets stripped."""
+
+    def test_invalid_ipv6_url_triggers_retry_with_stripped_brackets(self, monkeypatch):
+        from aci_tool import chat_semantic
+
+        calls = []
+
+        class FakeModel:
+            def encode(self, text, normalize_embeddings=True):
+                calls.append(text)
+                if "[" in text or "]" in text:
+                    raise ValueError("Invalid IPv6 URL")
+                return [0.0]
+
+        monkeypatch.setattr(
+            chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {})
+        )
+
+        result = chat_semantic.classify_sentence_semantic("visit https://[onion-link")
+        assert result == {}
+        assert len(calls) == 2
+        assert "[" not in calls[1] and "]" not in calls[1]
+
+    def test_unrelated_value_error_propagates(self, monkeypatch):
+        from aci_tool import chat_semantic
+
+        class FakeModel:
+            def encode(self, text, normalize_embeddings=True):
+                raise ValueError("some other problem")
+
+        monkeypatch.setattr(
+            chat_semantic, "_get_model_and_prototypes", lambda: (FakeModel(), {})
+        )
+
+        with pytest.raises(ValueError, match="some other problem"):
+            chat_semantic.classify_sentence_semantic("hello world")
+
+
 class TestExtractChatFeatures:
     @requires_model
     def test_basic_chat(self):


### PR DESCRIPTION
## What

Added error handling in `classify_sentence_semantic()` to gracefully handle `ValueError` exceptions raised by sentence_transformers when encoding sentences containing truncated bracketed URLs. When such an error occurs, the function now strips square brackets from the input and retries the encoding.

## Why

The sentence_transformers library uses `urlparse()` to detect image URLs in inputs. Chat content with truncated bracketed URLs (e.g., `https://[onion...`) causes Python 3.11+ to raise an "Invalid IPv6 URL" error during parsing. This fix allows the semantic classification to proceed by removing the problematic brackets while preserving the semantic meaning of the text.

## Testing

- [ ] `pytest tests/ -v` passes
- [ ] `ruff check .` passes

https://claude.ai/code/session_01GBMiWKNi3XocGqaXFRHYYr